### PR TITLE
Fix 404 links to numeric style sub-pages

### DIFF
--- a/data/menu/main.yaml
+++ b/data/menu/main.yaml
@@ -17,13 +17,13 @@ main:
     external: false
     sub:
       - name: Number Style
-        ref: "/number-styles/#number-style"
+        ref: "/numeric-styles/#number-style"
         external: true
       - name: Percent Style
-        ref: "/number-styles/#percent-style"
+        ref: "/numeric-styles/#percent-style"
         external: true
       - name: Currency Style
-        ref: "/number-styles/#currency-style"
+        ref: "/numeric-styles/#currency-style"
         external: true
   - name: Single Date Styles
     ref: "/date-styles/"


### PR DESCRIPTION
When clicking on any of the numeric sub-pages on the left menu, they go to a broken page because of the URL points to `number-styles` instead of `numeric-styles`: https://goshdarnformatstyle.com/numeric-styles/