### PR TITLE
Fix typo

### DIFF
--- a/content/_includes/quiz.md
+++ b/content/_includes/quiz.md
@@ -124,7 +124,7 @@ Apple added a date extension onto `Date` that lets you output the date and/or ti
 
 The `dateTime()` format style lets you compose a date string by choosing which date components you'd like to include. Each component can be further customized passing in some options.
 
-See <a href="/date-styles/#datetime-compositing-single-date">composting using .dateTime</a>
+See <a href="/date-styles/#datetime-compositing-single-date">compositing using .dateTime</a>
 
 {{< /expand >}}
 

--- a/sections/quiz.md
+++ b/sections/quiz.md
@@ -124,7 +124,7 @@ Apple added a date extension onto `Date` that lets you output the date and/or ti
 
 The `dateTime()` format style lets you compose a date string by choosing which date components you'd like to include. Each component can be further customized passing in some options.
 
-See <a href="/date-styles/#datetime-compositing-single-date">composting using .dateTime</a>
+See <a href="/date-styles/#datetime-compositing-single-date">compositing using .dateTime</a>
 
 {{< /expand >}}
 


### PR DESCRIPTION
This fixes the same typo in `content/_includes/quiz.md` and `sections/quiz.md`. I'm not 100 % sure if I'm supposed to fix this in both places or if one of these files is being generated from the source.

Feel free to close and fix it yourself if I did it wrong.