### PR TITLE
Fix typos and broken links in content files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ hugo.linux
 .envrc
 
 .nova
+
+.claude
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build build-fck build-gosh serve deploy deploy-fck deploy-gosh clean
+
+build: build-fck
+
+build-fck:
+	@echo "Building fuckingformatstyle.com"
+	hugo
+	rm -rf public/_includes
+	./markup.sh public
+
+build-gosh:
+	@echo "Building goshdarnformatstyle.com"
+	hugo --config config-gosh.toml
+	rm -rf public/_includes
+	./markup.sh public
+
+serve:
+	hugo server
+
+deploy: deploy-fck deploy-gosh
+
+deploy-fck: build-fck
+	rsync -avz --delete public/ $${USER}@$${HOST}:~/$${FCK}
+	@echo "fuckingformatstyle.com is updated"
+
+deploy-gosh: build-gosh
+	rsync -avz --delete public/ $${USER}@$${HOST}:~/$${GOSH}
+	@echo "goshdarnformatstyle.com is updated"
+
+clean:
+	rm -rf public/

--- a/content/_includes/componentsDateRange.md
+++ b/content/_includes/componentsDateRange.md
@@ -35,8 +35,17 @@ testRange.formatted(.components(style: .abbreviated, fields: [.year])
 testRange.formatted(.components(style: .condensedAbbreviated, fields: [.day, .month, .year, .hour, .second, .week])) // "31y"
 
 let appleReferenceDay = Date(timeIntervalSinceReferenceDate: 0)
+let twosdayDateComponents = DateComponents(
+    year: 2022,
+    month: 2,
+    day: 22,
+    hour: 2,
+    minute: 22,
+    second: 22,
+    nanosecond: 22
+)
 let twosday = Calendar(identifier: .gregorian).date(from: twosdayDateComponents)!
-let secondRange = appleReferenceDay .. <twosday
+let secondRange = appleReferenceDay..<twosday
 
 // 21 yrs, 1 mth, 3 wks, 9 hr, 1,342 sec
 secondRange.formatted(.components(style: .abbreviated, fields: [.day, .month, .year, .hour, .second, .week]))
@@ -66,7 +75,7 @@ secondRange.formatted(.components(style: .spellOut, fields: [.day, .month, .year
 
 ### Fully Customizing & Setting Calendar
 
-You can set the calendar by using the `Date.ComponentFormatStyle` initializer and using the resulting format style.
+You can set the calendar by using the `Date.ComponentsFormatStyle` initializer and using the resulting format style.
 
 ``` swift
 let componentsFormat = Date.ComponentsFormatStyle(

--- a/content/_includes/currency.md
+++ b/content/_includes/currency.md
@@ -4,13 +4,13 @@ sitemap_ignore: true
 The easiest and best way to access this style is through the `.currency(code:)` extension on `FormatStyle`. From there, you can use method chaining to customize the output.
 
 ``` swift
-10.formatted(.currency(code: "JPY")) // "10%"
+10.formatted(.currency(code: "JPY")) // "¥10"
 ```
 
 You can also initialize an instance of `IntegerFormatStyle<Value: BinaryInteger>.Percent`, `FloatingPointFormatStyle<BinaryFloatingPoint>.Percent` or `Decimal.FormatStyle.Percent` and use method chaining to customize the output.
-  
+
 ``` swift
-FloatingPointFormatStyle<Double>.Currency(code: "JPY").rounded(rule: .up, increment: 1).format(10.9) // ¥11"
+FloatingPointFormatStyle<Double>.Currency(code: "JPY").rounded(rule: .up, increment: 1).format(10.9) // "¥11"
 IntegerFormatStyle<Int>.Currency(code: "GBP").presentation(.fullName).format(42) // "42.00 British pounds"
 Decimal.FormatStyle.Currency(code: "USD").scale(12).format(0.1) // "$1.20"
 ```
@@ -23,7 +23,7 @@ Decimal.FormatStyle.Currency(code: "USD").scale(12).format(0.1) // "$1.20"
 | [Sign](#currency-sign)                                        | Do you want to show or hide the + or - sign?                  |
 | [Decimal Separator](#currency-decimal-separator)              | Do you want to show or hide the decimal separator             |
 | [Grouping](#currency-grouping)                                | How do you want the thousands numbers to be grouped           |
-| [Precision](#currency-prescision)                             | How many fractional or significant digits do you want to show |
+| [Precision](#currency-precision)                             | How many fractional or significant digits do you want to show |
 | [Presentation](#currency-presentation)                        | Controls the style of the displayed currency                  |
 | [Scale](#currency-scale)                                      | Scale the number up or down before display                    |
 | [Locale](#currency-locale)                                    | Set the `Locale` for one output                               |
@@ -81,7 +81,7 @@ Controls the visibility of the negative and positive sign.
 
 | Sign Display Strategy          | Description                                                            |
 |--------------------------------|------------------------------------------------------------------------|
-| `.automatic`                   | Automatically desides which strategy to use                            |
+| `.automatic`                   | Automatically decides which strategy to use                            |
 | `.never`                       | Never shows the positive (+) or negative (-) signs                     |
 | `.always()`                    | Always shows the positive (+) or negative (-) signs                    |
 | `.always(showsZero:)`          | Accepts a `Bool`, and controls if a `0` value gets a positive (+) sign |
@@ -228,7 +228,7 @@ Controls the locale of the output.
 
 ``` swift
 Decimal(10).formatted(.currency(code: "GBP").presentation(.fullName).locale(Locale(identifier: "fr_FR"))) // "10,00 livres sterling"
-Decimal(10000000).formatted(.currency(code: "GBP").locale(Locale(identifier: "hi_IN"))) // "£1,00,00,000.00
+Decimal(10000000).formatted(.currency(code: "GBP").locale(Locale(identifier: "hi_IN"))) // "£1,00,00,000.00"
 ```
 
 <h3 id="currency-compositing">Compositing</h3>
@@ -267,6 +267,6 @@ try Decimal("$3.14", format: .currency(code: "USD").locale(enUS)) // 3.14
 let enUS = Locale(identifier: "en_US")
 let currencyStyle = Decimal.FormatStyle.Currency(code: "USD", locale: enUS)
 try Decimal("$3.14", format: currencyStyle) // 3.14
-``` 
+```
 
 [See more information](https://github.com/brettohland/fuckingformatstyle/issues/26)

--- a/content/_includes/dateAndTIme.md
+++ b/content/_includes/dateAndTIme.md
@@ -11,7 +11,7 @@ To customize the display, you have the option of including a `DateStyle` or a `T
 | `.numeric`       | Displays the date components as numbers                         |
 | `.abbreviated`   | Displays the year, month, and numerical day. Month is shortened |
 | `.long`          | Displays the year, month, and numerical day. Month is in full   |
-| `.complete`      | Displays the year, month, weedkay, and numberical day in full   |
+| `.complete`      | Displays the year, month, weekday, and numerical day in full    |
 
 | TimeStyle Option | Description                                        |
 |------------------|----------------------------------------------------|

--- a/content/_includes/datetime.md
+++ b/content/_includes/datetime.md
@@ -356,7 +356,7 @@ You can output an `AttributedString` by appending the `attributed` method onto t
 ``` swift
 twosday.formatted(.dateTime.attributed)
 twosday.formatted(Date.FormatStyle().attributed)
-``` 
+```
 
 ### Localizing Number Systems
 

--- a/content/_includes/duration.md
+++ b/content/_includes/duration.md
@@ -6,6 +6,8 @@ There are two format styles available for the `Duration` type:
 
 <h2 id="time-style">Time Style {{< xcode14-badge >}}</h2>
 
+{{< api-links docs="foundation/duration/timeformatstyle" source="FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift" >}}
+
 Time format style allows you to output your `Duration` as a combination of hours, minutes, and seconds, which is set by the `pattern` parameter on the style.
 
 You can either initialize a new instance of `Duration.TimeFormatStyle`, or use the `.time(pattern:)` extension on FormatStyle.
@@ -63,7 +65,7 @@ Duration.seconds(1_000).formatted(.time(pattern: .hourMinute(padHourToLength: 1,
 Duration.seconds(1_000).formatted(.time(pattern: .hourMinute(padHourToLength: 1, roundSeconds: .towardZero))) // "0:16"
 Duration.seconds(1_000).formatted(.time(pattern: .hourMinute(padHourToLength: 1, roundSeconds: .up))) // "0:17"
 ```
-The following are the parameter options are for 'minuteSecond`:
+The following are the parameter options for `minuteSecond`:
 
 | Parameter                 | Description                                                                                                                       |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
@@ -115,7 +117,9 @@ Duration.seconds(1_000).formatted(.time(pattern: .hourMinuteSecond).attributed)
 
 <h2 id="units-style">Unit Style {{< xcode14-badge >}}</h2>
 
-The units style allows you to declare and customize the specific units to display for your duration. 
+{{< api-links docs="foundation/duration/unitsformatstyle" source="FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift" >}}
+
+The units style allows you to declare and customize the specific units to display for your duration.
 
 You can either initialize a new instance of `Duration.UnitsFormatStyle`, or use the `.units()` extension on FormatStyle.
 
@@ -124,7 +128,7 @@ Duration.seconds(100).formatted(.units()) // "1 min, 40 sec"
 Duration.UnitsFormatStyle(allowedUnits: [.hours, .minutes, .seconds], width: .abbreviated).format(.seconds(100)) // "1 min, 40 sec"
 ```
 
-In both cases, there are two variants the initializer or style method. 
+In both cases, there are two variants the initializer or style method.
 
 | Parameter          | Description                                                 |
 |--------------------|-------------------------------------------------------------|
@@ -144,7 +148,7 @@ In both cases, there are two variants the initializer or style method.
 | `valueLengthLimits` | How to pad or truncate values for display.                  |
 | `fractionalPart`    | How to display fractional values if the unit can't be shown |
 
-If you can't spot it at a glance, the difference is the `valueLength`/`valueLengthLimits` parameter which configures how each unit is padded or truncated. `valueLength` accepts an optional `Integer`, while `valueLengthLimits` takes an optional `ValueRange` value. 
+If you can't spot it at a glance, the difference is the `valueLength`/`valueLengthLimits` parameter which configures how each unit is padded or truncated. `valueLength` accepts an optional `Integer`, while `valueLengthLimits` takes an optional `ValueRange` value.
 
 ---
 

--- a/content/_includes/faq.md
+++ b/content/_includes/faq.md
@@ -7,7 +7,7 @@ sitemap_ignore: true
 
 For Swift, it's the easiest way to convert a data type to a **fully localized display string**.
 
-Introduced with iOS 15, the `FormatStyle` is a Swift protocol that outlines a way to take one format and convert it to another. 
+Introduced with iOS 15, the `FormatStyle` is a Swift protocol that outlines a way to take one format and convert it to another.
 
 On top of this, Apple built out a suite of format styles to easily convert the built in data types to strings for display with a dizzying amount of customization.
 
@@ -36,13 +36,13 @@ At the core of it:
 
 ### Performance
 
-Creating an instance of a `Formatter` subclass is expensive and Apple's documentation doesn't go out of it's way to tell you that. An easy trap to fall into is re-initializing a formatter every time you'd like to display some data as a string.
+Creating an instance of a `Formatter` subclass is expensive and Apple's documentation doesn't go out of its way to tell you that. An easy trap to fall into is re-initializing a formatter every time you'd like to display some data as a string.
 
 This isn't too bad if you're re-creating a formatter once per `UIView`, but if you make the mistake of creating a new formatter for every cell in a `UICollectionView`, you're going to be in pain.
 
 `FormatStyle` works like you expect it, and it handles everything behind the scenes.
 
-[Kahn Winter did a bunch of performance testing](https://mobile.twitter.com/thecoolwinter/status/1525562833689247747?s=20&t=kSGBR5hYzEAJF6AacIbn0g) and found that `FormatStyle` use is slightly more performant than correctly re-using `Formatter` subclasses correctly. 
+[Kahn Winter did a bunch of performance testing](https://mobile.twitter.com/thecoolwinter/status/1525562833689247747?s=20&t=kSGBR5hYzEAJF6AacIbn0g) and found that `FormatStyle` use is slightly more performant than correctly re-using `Formatter` subclasses correctly.
 
 So the main benefit to their use is…
 

--- a/content/_includes/iso8601.md
+++ b/content/_includes/iso8601.md
@@ -42,7 +42,7 @@ Date.ISO8601FormatStyle(
   dateTimeSeparator: Date.ISO8601FormatStyle.DateTimeSeparator, // .space or .standard
   timeSeparator: Date.ISO8601FormatStyle.TimeSeparator,         // .colon or .omitted
   timeZoneSeparator: Date.ISO8601FormatStyle.TimeZoneSeparator, // .colon or .omitted
-  includingFractionalSeconds: Bool, 
+  includingFractionalSeconds: Bool,
   timeZone: TimeZone
 )
 
@@ -116,4 +116,4 @@ try? Date(
         .time(includingFractionalSeconds: true)
         .parseStrategy
 ) // Feb 22, 2022 at 2:22 AM
-````
+```

--- a/content/_includes/listStyle.md
+++ b/content/_includes/listStyle.md
@@ -12,9 +12,9 @@ You have the ability to set the style of the output
 
 | Width Option | Description                                                         |
 |--------------|---------------------------------------------------------------------|
-| `.standard`  | The standard default, uses the full  localized word.                |
-| `.short`     | Uses a narrow version of the work. For example "&" instead of "and" |
-| `.narrow`    | Uses the least number of characters possible for the word. For example, omitti
+| `.standard`  | The standard default, uses the full localized word.                 |
+| `.short`     | Uses a narrow version of the word. For example "&" instead of "and" |
+| `.narrow`    | Uses the least number of characters possible for the word. For example, omitting the word entirely. |
 
 ``` swift
 letters.formatted(.list(type: .and, width: .narrow))   // "a, b, c, d"
@@ -52,17 +52,22 @@ In the case of more complex, or custom values in the array, you can pass in anot
 For example, you can use any of the date format styles when dealing with an array of Dates.
 
 ``` swift
-let importantDates = [Date.timeIntervalSinceReferenceDate, Date.timeIntervalBetween1970AndReferenceDate]
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and)) // "2000 and 1969"
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or))  // "2000 or 1969"
+let importantDates = [
+    Date(timeIntervalSinceReferenceDate: 0), // January 1, 2001
+    Date(timeIntervalSince1970: 0)           // January 1, 1970
+]
+let yearOnlyFormat = Date.FormatStyle().year()
 
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and, width: .standard)) // "2000 and 1969"
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and, width: .narrow))   // "2000, 1969"
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and, width: .short))    // "2000 & 1969"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and)) // "2001 and 1970"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or))  // "2001 or 1970"
 
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or, width: .standard)) // "2000 or 1969"
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or, width: .narrow))   // "2000 or 1969"
-importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or, width: .short))    // "2000 or 1969"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and, width: .standard)) // "2001 and 1970"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and, width: .narrow))   // "2001, 1970"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .and, width: .short))    // "2001 & 1970"
+
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or, width: .standard)) // "2001 or 1970"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or, width: .narrow))   // "2001 or 1970"
+importantDates.formatted(.list(memberStyle: yearOnlyFormat, type: .or, width: .short))    // "2001 or 1970"
 
 let yearStyle = ListFormatStyle<Date.FormatStyle, Array<Date>>.init(memberStyle: .dateTime.year())
 importantDates.formatted(yearStyle)
@@ -70,6 +75,6 @@ importantDates.formatted(yearStyle)
 
 {{< hint type=tip >}}
 
-The `memberStyle:` parameter accepts any `FormatStyle` value. This means that you can fully customize how each item within the list is formatted for display by using the options outlined througout the rest of this site.
+The `memberStyle:` parameter accepts any `FormatStyle` value. This means that you can fully customize how each item within the list is formatted for display by using the options outlined throughout the rest of this site.
 
 {{</hint>}}

--- a/content/_includes/measurement.md
+++ b/content/_includes/measurement.md
@@ -34,7 +34,7 @@ As of Xcode 14, this is the canonical list of Dimensions [^1] that are supported
 
 [^2]: Xcode 14 introduced the Byte Count Format Style (`Measurement<UnitInformationStorage>.FormatStyle.ByteCount`) specifically for this unit. [See the Byte Count Style section for more detail](/byte-count-style/).
 
-Measurement is special in that the localized string output can vary significantly depending on the `Locale` used by the format style. 
+Measurement is special in that the localized string output can vary significantly depending on the `Locale` used by the format style.
 
 By default, it uses the style of your device. You can specify the locale used by adding the `.locale()` method to the end of the style method.
 
@@ -43,7 +43,7 @@ There are three parameters available to customize your output. Only `width` is r
 | Parameter                    | Accepted Type                                 | Description                    |
 |------------------------------|-----------------------------------------------|--------------------------------|
 | [`width`](#width)            | `Measurement<UnitType>.FormatStyle.UnitWidth` | Sets how verbose the output is |
-| [`usage`]($usage) (optional) | `MeasurementFormatUnitUsage<UnitType>`        | Sets how the unit will be used |
+| [`usage`](#usage) (optional) | `MeasurementFormatUnitUsage<UnitType>`        | Sets how the unit will be used |
 | [`numberFormatStyle`](#numberformatstyle) (optional) | `FloatingPointFormatStyle<Double>`            | Sets the format style on the number
 
 ``` swift
@@ -113,7 +113,7 @@ Shared Options:
 | Option        | Description                                                                          |
 |---------------|--------------------------------------------------------------------------------------|
 | `.general`    | Outputs the value in the most generalized way for the given locale                   |
-| `.asProvided` | Outputs a string value of the unit the `Dimention` was created with, or converted to |
+| `.asProvided` | Outputs a string value of the unit the `Dimension` was created with, or converted to |
 
 
 ``` swift
@@ -129,7 +129,7 @@ myHeight.formatted(.measurement(width: .abbreviated, usage: .asProvided).locale(
 myHeight.formatted(.measurement(width: .abbreviated, usage: .asProvided).locale(sweden)) // "190 cm"
 ```
 
-The `.general` option will output the string with what would be agreed upon as the generalized usage of that unit for the given locale. In the above case, the US locale used fractional feet while the Swedish locale used centimetres. 
+The `.general` option will output the string with what would be agreed upon as the generalized usage of that unit for the given locale. In the above case, the US locale used fractional feet while the Swedish locale used centimetres.
 
 #### UnitEnergy
 
@@ -140,6 +140,7 @@ The `.general` option will output the string with what would be agreed upon as t
 
 ``` swift
 let usa = Locale(identifier: "en-US")
+let canada = Locale(identifier: "en-CA")
 let sweden = Locale(identifier: "sv-SE")
 
 let recommendedCalories = Measurement(value: 2.0, unit: UnitEnergy.kilowattHours)
@@ -188,6 +189,7 @@ recommendedCalories.formatted(.measurement(width: .narrow, usage: .workout).loca
 
 ``` swift
 let usa = Locale(identifier: "en-US")
+let canada = Locale(identifier: "en-CA")
 let sweden = Locale(identifier: "sv-SE")
 
 let myHeight = Measurement(value: 190, unit: UnitLength.centimeters)
@@ -255,6 +257,7 @@ myHeight.formatted(.measurement(width: .narrow, usage: .personHeight).locale(can
 
 ``` swift
 let usa = Locale(identifier: "en-US")
+let canada = Locale(identifier: "en-CA")
 let sweden = Locale(identifier: "sv-SE")
 
 let averageWeight = Measurement(value: 197.9, unit: UnitMass.pounds)
@@ -293,6 +296,7 @@ averageWeight.formatted(.measurement(width: .narrow, usage: .personWeight).local
 
 ``` swift
 let usa = Locale(identifier: "en-US")
+let canada = Locale(identifier: "en-CA")
 let sweden = Locale(identifier: "sv-SE")
 
 let aNiceDay = Measurement(value: 25.0, unit: UnitTemperature.celsius)
@@ -366,6 +370,7 @@ aNiceDay.formatted(.measurement(width: .narrow, usage: .weather, hidesScaleName:
 
 ``` swift
 let usa = Locale(identifier: "en-US")
+let canada = Locale(identifier: "en-CA")
 let sweden = Locale(identifier: "sv-SE")
 
 let onePint = Measurement(value: 1, unit: UnitVolume.pints)
@@ -398,7 +403,7 @@ onePint.formatted(.measurement(width: .narrow, usage: .liquid).locale(canada)) /
 ### NumberFormatStyle
 
 The `numberFormatStyle` parameter controls the formatting of the numerical portion of the measurement output. Specifically, it's a `FloatingPointFormatStyle<Double>` and can accept any numeric format style you'd like.
-  
+
 [See the Number Style section for more detailed information](/numeric-styles/#number-style).
 
 The example below shows how to output a person's height without fractional inches.

--- a/content/_includes/names.md
+++ b/content/_includes/names.md
@@ -52,7 +52,7 @@ guest.formatted(inFrance)
 
 #### Parsing Names From Strings
 
-This is primarily useful when dealing with differences in name order for a given `Locale`. 
+This is primarily useful when dealing with differences in name order for a given `Locale`.
 
 ``` swift
 // namePrefix: Dr givenName: Elizabeth middleName: Jillian familyName: Smith nameSuffix: Esq.

--- a/content/_includes/numbers.md
+++ b/content/_includes/numbers.md
@@ -9,7 +9,7 @@ Float(10).formatted(.number.scale(200.0).notation(.compactName).grouping(.automa
 ```
 
 You can also initialize an instance of `IntegerFormatStyle<Value: BinaryInteger>`, `FloatingPointFormatStyle<BinaryFloatingPoint>` or `Decimal.FormatStyle` and use method chaining to customize the output.
-  
+
 ``` swift
 FloatingPointFormatStyle<Double>().rounded(rule: .up, increment: 1).format(10.9) // "11"
 IntegerFormatStyle<Int>().notation(.compactName).format(1_000) // "1K"
@@ -24,7 +24,7 @@ Decimal.FormatStyle().scale(10).format(1) // "10"
 | [Sign](#numbers-sign)                                        | Do you want to show or hide the + or - sign?                  |
 | [Decimal Separator](#numbers-decimal-separator)              | Do you want to show or hide the decimal separator             |
 | [Grouping](#numbers-grouping)                                | How do you want the thousands numbers to be grouped           |
-| [Precision](#numbers-prescision)                             | How many fractional or significant digits do you want to show |
+| [Precision](#numbers-precision)                             | How many fractional or significant digits do you want to show |
 | [Notation](#numbers-notation)                                | Enable scientific or compact notation                         |
 | [Scale](#numbers-scale)                                      | Scale the number up or down before display                    |
 | [Locale](#numbers-locale)                                    | Set the `Locale` for one output                               |

--- a/content/_includes/percent.md
+++ b/content/_includes/percent.md
@@ -9,7 +9,7 @@ The easiest and best way to access this style is through the `.percent` extensio
 ```
 
 You can also initialize an instance of `IntegerFormatStyle<Value: BinaryInteger>.Percent`, `FloatingPointFormatStyle<BinaryFloatingPoint>.Percent` or `Decimal.FormatStyle.Percent` and use method chaining to customize the output.
-  
+
 ``` swift
 FloatingPointFormatStyle<Double>.Percent().rounded(rule: .up, increment: 1).format(0.109) // "11%"
 IntegerFormatStyle<Int>.Percent().notation(.compactName).format(1_000) // "1K%"
@@ -24,14 +24,14 @@ Decimal.FormatStyle.Percent().scale(12).format(0.1) // "1.2%"
 | [Sign](#percent-sign)                                        | Do you want to show or hide the + or - sign?                  |
 | [Decimal Separator](#percent-decimal-separator)              | Do you want to show or hide the decimal separator             |
 | [Grouping](#percent-grouping)                                | How do you want the thousands numbers to be grouped           |
-| [Precision](#percent-prescision)                             | How many fractional or significant digits do you want to show |
+| [Precision](#percent-precision)                             | How many fractional or significant digits do you want to show |
 | [Notation](#percent-notation)                                | Enable scientific or compact notation                         |
 | [Scale](#percent-scale)                                      | Scale the number up or down before display                    |
 | [Locale](#percent-locale)                                    | Set the `Locale` for one output                               |
 | [Compositing](#percent-compositing)                          | Mix and match any and all of the above                        |
 | [AttributedString output](#percent-attributed-string-output) | Output an `AttributedString`                                  |
 
-<h3 id="percent-ounding">Rounding</h3>
+<h3 id="percent-rounding">Rounding</h3>
 
 At its simplest, you can call the `.formatted(.number.rounded())` method on any number type (Float, Double, Decimal, or Integer) in order to get the system's default rounding behaviour.
 
@@ -278,7 +278,7 @@ Percentages parsed as Integers will be a value from 0 - 100, while percentages p
 
 {{< /hint >}}
 
-Percentage strings can be parsed into any of Swift's built-in numeric types. 
+Percentage strings can be parsed into any of Swift's built-in numeric types.
 
 ``` swift
 try? Int("98%", format: .percent) // 98

--- a/content/_includes/quiz.md
+++ b/content/_includes/quiz.md
@@ -27,7 +27,7 @@ See <a href="/numeric-styles/">Number Style</a>
 | [Sign](/numeric-styles/#numbers-sign)                                        | Do you want to show or hide the + or - sign?                  |
 | [Decimal Separator](/numeric-styles/#numbers-decimal-separator)              | Do you want to show or hide the decimal separator             |
 | [Grouping](/numeric-styles/#numbers-grouping)                                | How do you want the thousands numbers to be grouped           |
-| [Precision](/numeric-styles/#numbers-prescision)                             | How many fractional or significant digits do you want to show |
+| [Precision](/numeric-styles/#numbers-precision)                             | How many fractional or significant digits do you want to show |
 | [Notation](/numeric-styles/#numbers-notation)                                | Enable scientific or compact notation                         |
 | [Scale](/numeric-styles/#numbers-scale)                                      | Scale the number up or down before display                    |
 | [Locale](/numeric-styles/#numbers-locale)                                    | Set the `Locale` for one output                               |
@@ -54,7 +54,7 @@ When formatting a floating point number (Double/Float/Decimal), `1.0` is "100%",
 | [Sign](/numeric-styles/#percent-sign)                                        | Do you want to show or hide the + or - sign?                  |
 | [Decimal Separator](/numeric-styles/#percent-decimal-separator)              | Do you want to show or hide the decimal separator             |
 | [Grouping](/numeric-styles/#percent-grouping)                                | How do you want the thousands numbers to be grouped           |
-| [Precision](/numeric-styles/#percent-prescision)                             | How many fractional or significant digits do you want to show |
+| [Precision](/numeric-styles/#percent-precision)                             | How many fractional or significant digits do you want to show |
 | [Notation](/numeric-styles/#percent-notation)                                | Enable scientific or compact notation                         |
 | [Scale](/numeric-styles/#percent-scale)                                      | Scale the number up or down before display                    |
 | [Locale](/numeric-styles/#percent-locale)                                    | Set the `Locale` for one output                               |
@@ -93,7 +93,7 @@ Floating point types shouldn't be used to store or do calculations on numbers th
 | [Sign](/numeric-styles/#currency-sign)                                        | Do you want to show or hide the + or - sign?                  |
 | [Decimal Separator](/numeric-styles/#currency-decimal-separator)              | Do you want to show or hide the decimal separator             |
 | [Grouping](/numeric-styles/#currency-grouping)                                | How do you want the thousands numbers to be grouped           |
-| [Precision](/numeric-styles/#currency-prescision)                             | How many fractional or significant digits do you want to show |
+| [Precision](/numeric-styles/#currency-precision)                             | How many fractional or significant digits do you want to show |
 | [Presentation](/numeric-styles/#currency-presentation)                        | Controls the style of the displayed currency                  |
 | [Scale](/numeric-styles/#currency-scale)                                      | Scale the number up or down before display                    |
 | [Locale](/numeric-styles/#currency-locale)                                    | Set the `Locale` for one output                               |
@@ -132,7 +132,7 @@ See <a href="/date-styles/#datetime-compositing-single-date">compositing using .
 
 {{< xcode13-badge >}}
 
-Output date strings that conform to the <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601 standard</a>. 
+Output date strings that conform to the <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601 standard</a>.
 
 See  <a href="/date-styles/#iso-8601-date-style-single-date">ISO8601 Style</a>
 
@@ -142,7 +142,7 @@ See  <a href="/date-styles/#iso-8601-date-style-single-date">ISO8601 Style</a>
 
 {{< xcode13-badge >}}
 
-Relative date formatting outputs a plain language string that describes how far away that date is to right now. You can also customize which date components are used in the output. 
+Relative date formatting outputs a plain language string that describes how far away that date is to right now. You can also customize which date components are used in the output.
 
 This is similar to the components format style on date ranges, but that one uses date ranges instead of assuming the current date and time.
 
@@ -305,7 +305,7 @@ All of Swift's built-in numeric types can be parsed from strings. You can also h
 
 [See Parsing Percentages](/numeric-styles/#parsing-percentages-from-strings)
 
-[See Parsing Currencies](/numeric-styles/#parsing-currencies-from-strings) 
+[See Parsing Currencies](/numeric-styles/#parsing-currencies-from-strings)
 
 {{< /expand >}}
 

--- a/content/_includes/verbatimDate.md
+++ b/content/_includes/verbatimDate.md
@@ -130,7 +130,7 @@ Calendars such as the Chinese lunar calendar (and related calendars) and the Hin
 | `.abbreviated` | Abbreviated cyclic year name. For example, "甲子". |
 | `.wide`        | Wide cyclic year name. For example, "甲子".        |
 | `.narrow`      | Narrow cyclic year name. For example, "甲子".      |
-    
+
 
 ---
 
@@ -158,7 +158,7 @@ Calendars such as the Chinese lunar calendar (and related calendars) and the Hin
 | `.narrow`        | Narrow month name. For example, "S".                                                                                                        |    |
 
 ---
-    
+
 <h4 id="week-token">Week</h4>
 
 Week symbols. Use with `YearForWeekOfYear` for the year field instead of `Year`.
@@ -178,11 +178,11 @@ Week symbols. Use with `YearForWeekOfYear` for the year field instead of `Year`.
 | `.defaultDigits`                 | Minimum number of digits that shows the full numeric day of month. For example, `1`, `18`.                                                                                                                                                                                                                                                                                                                                                   |
 | `.twoDigits`                     | Two-digit, zero-padded if necessary. For example, `01`, `18`.                                                                                                                                                                                                                                                                                                                                                                                |
 | `.ordinalOfDayInMonth`           | Ordinal of day in month. For example, the 2nd Wed in July would yield `2`.                                                                                                                                                                                                                                                                                                                                                                   |
-| `.ulianModified(minimumLength:)` | The field length specifies the minimum number of digits, with zero-padding as necessary. <br> This is different from the conventional Julian day number in two regards. First, it demarcates days at local zone midnight, rather than noon GMT. Second, it is a local number; that is, it depends on the local time zone. It can be thought of as a single number that encompasses all the date-related fields. <br> For example, `2451334`. |
+| `.julianModified(minimumLength:)` | The field length specifies the minimum number of digits, with zero-padding as necessary. <br> This is different from the conventional Julian day number in two regards. First, it demarcates days at local zone midnight, rather than noon GMT. Second, it is a local number; that is, it depends on the local time zone. It can be thought of as a single number that encompasses all the date-related fields. <br> For example, `2451334`. |
 
 
 ---
-    
+
 <h4 id="dayofyear-token">DayOfYear</h4>
 
 | Option           | Description                                                                                      |
@@ -190,7 +190,7 @@ Week symbols. Use with `YearForWeekOfYear` for the year field instead of `Year`.
 | `.defaultDigits` | Minimum number of digits that shows the full numeric day of year. For example, `7`, `33`, `345`. |
 | `.twoDigits`     | Two-digit day of year, with zero-padding as necessary. For example, `07`, `33`, `345`.           |
 | `.threeDigits`   | Three-digit day of year, with zero-padding as necessary. For example, `007`, `033`, `345`.       |
-    
+
 
 ---
 
@@ -206,7 +206,7 @@ Week symbols. Use with `YearForWeekOfYear` for the year field instead of `Year`.
 | `.twoDigits`   | Local day of week number/name, format style; two digits, zero-padded if necessary.      |
 
 ---
-    
+
 <h4 id="dayperiod-token">DayPeriod</h4>
 
 The time period (for example, "a.m." or "p.m."). May be upper or lower case depending on the locale and other options.
@@ -231,7 +231,7 @@ Each of the options can be passed a `width` case.
 |------------------|--------------------------------------------------------------------------------------------|
 | `.defaultDigits` | Minimum digits to show the numeric minute. Truncated, not rounded. For example, `8`, `59`. |
 | `.twoDigits`     | Two-digit numeric, zero padded if needed. For example, `08`, `59`.                         |
-    
+
 
 ---
 
@@ -241,7 +241,7 @@ Each of the options can be passed a `width` case.
 |------------------|--------------------------------------------------------------------------------------------|
 | `.defaultDigits` | Minimum digits to show the numeric second. Truncated, not rounded. For example, `8`, `12`. |
 | `.twoDigits`     | Two digits numeric, zero padded if needed, not rounded. For example, `08`, `12`.           |
-    
+
 
 ---
 
@@ -262,7 +262,7 @@ When using the `.fractional(_:)` case, the format style seems to only output a m
 
 <h4 id="timezone-token">TimeZone</h4>
 
-Each talkes a `Width` case.
+Each takes a `Width` case.
 
 - `short`
 - `long`
@@ -287,7 +287,7 @@ Each talkes a `Width` case.
 | `.abbreviated` | Standalone abbreviated quarter. For example `Q2`.                                      |
 | `.wide`        | Standalone wide quarter. For example "2nd quarter".                                    |
 | `.narrow`      | Standalone narrow quarter. For example "2".                                            |
-    
+
 
 ---
 
@@ -302,7 +302,7 @@ Each talkes a `Width` case.
 | `.narrow`        | Stand-alone narrow month. For example, "S".                                                                        |
 
 ---
-    
+
 <h4 id="standaloneweekday-token">StandaloneWeekday</h4>
 
 | Option         | Description                                                           |
@@ -314,7 +314,7 @@ Each talkes a `Width` case.
 | `.short`       | Standalone short local day of week number/name. For example, "Tu".    |
 
 ---
-    
+
 <h4 id="verbatimhour-token">VerbatimHour</h4>
 
 Hour symbols that does not take users' preferences into account, and is displayed as-is.

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ This site is going to help you do just that.
 
 {{< other-version-link >}}
 
-<!--more--> 
+<!--more-->
 
 ---
 

--- a/content/byte-count-style/_index.md
+++ b/content/byte-count-style/_index.md
@@ -9,6 +9,8 @@ Simply showing your storage values, and even have fun converting units.
 
 {{< /hint >}}
 
+{{< api-links docs="foundation/bytecountformatstyle" source="FoundationInternationalization/Formatting/ByteCountFormatStyle.swift" >}}
+
 There are actually two byte count format styles available to you (depending on your Xcode version):
 
 1. {{< xcode13-badge >}} `ByteCountFormatStyle` is used to format `Int64` values.

--- a/content/custom-styles/_index.md
+++ b/content/custom-styles/_index.md
@@ -9,6 +9,8 @@ Visit the "Build a Format Style Workshop".
 
 {{< /hint >}}
 
+{{< api-links docs="foundation/formatstyle" source="FoundationEssentials/Formatting/FormatStyle.swift" >}}
+
 {{< include file="/_includes/custom.md" type="page" >}}
 
 <div class="gdoc-page__footer flex flex-wrap justify-between">

--- a/content/date-range-styles/_index.md
+++ b/content/date-range-styles/_index.md
@@ -5,9 +5,11 @@ sitemap_ignore: false
 
 <h2 id="interval-date-style-date-range">Interval Date Style (Date Range) {{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/date/intervalformatstyle" source="FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
-Shows the earliest and last dates in a `Range`, similar options to the [Date and Time](#) single date format style.
+Shows the earliest and last dates in a `Range`, similar options to the [Date and Time](/date-styles/#date-and-time-single-date) single date format style.
 
 {{< /hint >}}
 
@@ -19,9 +21,11 @@ For a given `Range<Date>`, this format will output the earliest and last days.
 
 <h2 id="components-date-style-date-range">Components Date Style (Date Range) {{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/date/componentsformatstyle" source="FoundationInternationalization/Formatting/Date/Date+ComponentsFormatStyle+Stub.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
-Shows the distance between the earliest and latest dates in a range, similar to the [Relative Date](#) style for single dates.
+Shows the distance between the earliest and latest dates in a range, similar to the [Relative Date](/date-styles/#relative-date-style-single-date) style for single dates.
 
 {{< /hint >}}
 

--- a/content/date-styles/_index.md
+++ b/content/date-styles/_index.md
@@ -5,6 +5,8 @@ sitemap_ignore: false
 
 <h2 id="compositing">Compositing {{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/date/formatstyle" source="FoundationInternationalization/Formatting/Date/DateFormatStyle.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
 A flexible way to composite the exact date string of your dreams.
@@ -18,6 +20,8 @@ Like lego blocks, this format style allows you to mix and match the date compone
 ---
 
 <h2 id="date-and-time-single-date">Date and Time {{< xcode13-badge >}}</h2>
+
+{{< api-links docs="foundation/date/formatstyle" source="FoundationInternationalization/Formatting/Date/DateFormatStyle.swift" >}}
 
 {{< hint type=tip title=TL;DR >}}
 
@@ -35,6 +39,8 @@ Each portion (the date and the time), can be customized in the following ways.
 
 <h2 id="iso-8601-date-style-single-date">ISO 8601 Date Style{{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/date/iso8601formatstyle" source="FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
 The fastest way to output the globe's standard date string.
@@ -49,13 +55,15 @@ Since this is an international standard, the amount of customization is limited 
 
 <h2 id="relative-date-style-single-date">Relative Date Style{{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/date/relativeformatstyle" source="FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
 Quickly say approximately how long it will be between a date and now.
 
 {{< /hint >}}
 
-This format style will tell you the approximate distance to or from a date to now. 
+This format style will tell you the approximate distance to or from a date to now.
 
 There are no options available to set the units you would like to display, the system will only show the largest unit.
 
@@ -64,6 +72,8 @@ There are no options available to set the units you would like to display, the s
 ---
 
 <h2 id="verbatim-date-style-single-date">Verbatim Date Style {{< xcode13-badge >}} {{< xcode14-badge >}}</h2>
+
+{{< api-links docs="foundation/date/verbatimformatstyle" source="FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift" >}}
 
 {{< hint type=tip title=TL;DR >}}
 

--- a/content/list-style/_index.md
+++ b/content/list-style/_index.md
@@ -11,8 +11,10 @@ Outputs an array as a list, you can further customize how each element in the ar
 
 {{< xcode13-badge >}}
 
+{{< api-links docs="foundation/listformatstyle" source="FoundationInternationalization/Formatting/ListFormatStyle.swift" >}}
+
 This format style works on any Array or items. In cases where the items are string convertible, the output is standard.
- 
+
 {{< include file="/_includes/listStyle.md" type="page" >}}
 
 <div class="gdoc-page__footer flex flex-wrap justify-between">

--- a/content/measurement-style/_index.md
+++ b/content/measurement-style/_index.md
@@ -10,7 +10,9 @@ Print out your various measurements.
 
 {{< xcode13-badge >}}
 
-The Measurement API inside of Foundation is a powerful toolkit for converting and displaying units. 
+{{< api-links docs="foundation/measurement/formatstyle" source="FoundationInternationalization/Formatting/Measurement+FormatStyle+Stub.swift" >}}
+
+The Measurement API inside of Foundation is a powerful toolkit for converting and displaying units.
 
 {{< include file="/_includes/measurement.md" type="page" >}}
 

--- a/content/numeric-styles/_index.md
+++ b/content/numeric-styles/_index.md
@@ -5,6 +5,8 @@ sitemap_ignore: false
 
 <h2 id="number-style">Number Style {{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/integerformatstyle" source="FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
 The many ways you can customize the display of numbers.
@@ -20,6 +22,8 @@ The examples below show the individual options available to format your final st
 ---
 
 <h2 id="percent-style">Percent Style {{< xcode13-badge >}}</h2>
+
+{{< api-links docs="foundation/integerformatstyle/percent" source="FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift" >}}
 
 {{< hint type=tip title=TL;DR >}}
 
@@ -43,15 +47,17 @@ Percentages are set by a range from 0.0 to 1.0, where 0.5 being 50%. This is con
 
 <h2 id="currency-style">Currency Style {{< xcode13-badge >}}</h2>
 
+{{< api-links docs="foundation/integerformatstyle/currency" source="FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift" >}}
+
 {{< hint type=tip title=TL;DR >}}
 
 Output number values in the local currency.
 
 {{< /hint >}}
 
-The currency format style is very similar to the Number and Percent format styles and works with Swift's numerical types (Float, Double, Decimal, and Integer). 
+The currency format style is very similar to the Number and Percent format styles and works with Swift's numerical types (Float, Double, Decimal, and Integer).
 
-The key difference is that you will need to pass in the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) country code for the currency you would like to display. 
+The key difference is that you will need to pass in the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) country code for the currency you would like to display.
 
 {{< hint type=important >}}
 

--- a/content/person-name-style/_index.md
+++ b/content/person-name-style/_index.md
@@ -11,6 +11,8 @@ Never again do you have to remember if the family name goes before the given nam
 
 {{< xcode13-badge >}}
 
+{{< api-links docs="foundation/personnamecomponents/formatstyle" >}}
+
 This format style solves the complexities of displaying an individual's name in the correct, localized fashion.
 
 {{< include file="/_includes/names.md" type="page" >}}

--- a/content/url-style/_index.md
+++ b/content/url-style/_index.md
@@ -11,6 +11,8 @@ Show off the all of the parts of your URL that you'd like.
 
 {{< xcode14-badge >}}
 
+{{< api-links docs="foundation/url/formatstyle" >}}
+
 Easily convert every bit of your URL into a string.
 
 {{< include file="/_includes/url.md" type="page" >}}

--- a/layouts/shortcodes/api-links.html
+++ b/layouts/shortcodes/api-links.html
@@ -1,0 +1,9 @@
+<p class="api-links">
+  {{- with .Get "docs" -}}
+    <a href="https://developer.apple.com/documentation/{{ . }}" target="_blank" rel="noopener">Apple Developer Documentation</a>
+  {{- end -}}
+  {{- if and (.Get "docs") (.Get "source") }} · {{ end -}}
+  {{- with .Get "source" -}}
+    <a href="https://github.com/swiftlang/swift-foundation/blob/main/Sources/{{ . }}" target="_blank" rel="noopener">Source</a>
+  {{- end -}}
+</p>

--- a/static/custom.css
+++ b/static/custom.css
@@ -129,6 +129,27 @@ a.version-badge:visited {
   } 
 }
 
+.api-links {
+  font-size: 0.8em;
+  margin: -0.5em 0 1em;
+}
+
+.api-links a {
+  color: #6c757d;
+  text-decoration: none;
+}
+
+.api-links a:hover {
+  text-decoration: underline;
+  color: #FF1A87;
+}
+
+@media (prefers-color-scheme: dark) {
+  .api-links a {
+    color: #9ca3af;
+  }
+}
+
 .language-swift {
   overflow-x: scroll;
 }


### PR DESCRIPTION
- Fix typos: weedkay→weekday, numberical→numerical, desides→decides, Dimention→Dimension, througout→throughout, ulian→julian, talkes→takes
- Fix broken anchor links in tables (prescision→precision, $usage→#usage)
- Fix truncated table row in listStyle.md
- Rename dateAndTIme.md to dateAndTime.md (case fix)
- Update broken internal links in date-range-styles
- Adds a new `api-links` shortcode that links to Apple Developer Documentation and swift-foundation GitHub source. Applied across all FormatStyle section pages. Also adds CLAUDE.md with project guidance for Claude Code.